### PR TITLE
update lars partition function

### DIFF
--- a/hmda-etl-pipeline/src/hmda_etl_pipeline/pipelines/ingest_data_from_pg/pipeline.py
+++ b/hmda-etl-pipeline/src/hmda_etl_pipeline/pipelines/ingest_data_from_pg/pipeline.py
@@ -42,7 +42,6 @@ for year in (2019, 2020, 2021, 2022, 2023, 2024):
             process_lar_partitions,
             inputs={
                 "pg_lar_data": f"pg_lar_{year}",
-                "lar_row_counts_by_lei": f"pg_lar_counts_by_lei_{year}",
                 "column_dtypes": "params:pg_lar_dtypes",
                 "count_verification_passed": f"count_verification_passed_{year}",
             },
@@ -113,7 +112,6 @@ for year in (2019, 2020, 2021, 2022, 2023, 2024):
                 process_lar_partitions,
                 inputs={
                     "pg_lar_data": f"pg_lar_{year}_{quarter}",
-                    "lar_row_counts_by_lei": f"pg_lar_counts_by_lei_{year}_{quarter}",
                     "column_dtypes": "params:pg_lar_dtypes",
                     "count_verification_passed": f"count_verification_passed_{year}_{quarter}",
                 },


### PR DESCRIPTION
update lars partition function removing`lar_row_counts_by_lei` parameter.  

Originally, it's used to calculate the size of the lar data chunks returned by sql query.  this means that we need to run another sql query. 

Found out that the chunks list is returned as iterable type so we can use regular loop to into each chunk (and skip the `lar_row_counts_by_lei` sql query)

Tested by running 2023 annual and Q3 lars data locally (`lar_raw_parquets_2023` and `lar_raw_parquets_2023_q2` outputs) and verified that the parquet output files count and contents are the same

closes #11 