### PR TITLE
remove mlar validations

### DIFF
--- a/hmda-etl-pipeline/src/hmda_etl_pipeline/pipelines/data_publisher/nodes.py
+++ b/hmda-etl-pipeline/src/hmda_etl_pipeline/pipelines/data_publisher/nodes.py
@@ -122,24 +122,6 @@ def analyze_mlar_flat_file(
             globals()[check](mlar_df, params, year, col)
     return mlar_df
 
-
-def validate_lar_and_mlar_row_counts(lar_row_count: int, mlar_row_count: int) -> None:
-    """Ensures the MLAR flat file and LAR flat files have the same
-    number of rows.
-
-    Args:
-        lar_row_count (int): Number of rows in regulator LAR flat file
-        mlar_row_count (int): Number of rows in public MLAR flat file
-
-    Raises:
-        RuntimeError: raised if the two don't aggree.
-    """
-    if lar_row_count != mlar_row_count:
-        raise RuntimeError(
-            f"Row count mismatch. LAR: {lar_row_count}, MLAR: {mlar_row_count}"
-        )
-
-
 def _process_modified_lar_partition(
     lar_df: pd.DataFrame,
     mlar_legacy_column_names_map_list: List[Dict[str, str]],

--- a/hmda-etl-pipeline/src/hmda_etl_pipeline/pipelines/data_publisher/pipeline.py
+++ b/hmda-etl-pipeline/src/hmda_etl_pipeline/pipelines/data_publisher/pipeline.py
@@ -37,7 +37,7 @@ for year in (2019, 2020, 2021, 2022, 2023, 2024):
             create_lar_flat_file,
             inputs=[f"lar_raw_parquets_{year}", "params:regulator_lar_columns"],
             outputs=[f"regulator_lar_flat_file_{year}", f"reg_lar_row_count_{year}"],
-            tags=f"{year}_Filing_Season",
+            tags=[f"{year}_Filing_Season", f"{year}_Annual_Filing_Season"],
             name=f"generate_reg_lar_flat_file_for_{year}",
         ),
         # Create LAR loan limit flat file
@@ -48,7 +48,7 @@ for year in (2019, 2020, 2021, 2022, 2023, 2024):
                 f"lar_loan_limit_flat_file_{year}",
                 f"lar_loan_limit_row_count_{year}",
             ],
-            tags=f"{year}_Filing_Season",
+            tags=[f"{year}_Filing_Season", f"{year}_Annual_Filing_Season"],
             name=f"generate_lar_loan_limit_flat_file_for_{year}",
         ),
         # Convert LAR data to public modified LAR data
@@ -59,7 +59,7 @@ for year in (2019, 2020, 2021, 2022, 2023, 2024):
                 "params:public_mlar_legacy_column_names_map_list",
             ],
             outputs=f"public_modified_lar_raw_parquets_{year}",
-            tags=f"{year}_Filing_Season",
+            tags=[f"{year}_Filing_Season", f"{year}_Annual_Filing_Season"],
             name=f"generate_public_modified_lar_for_{year}",
         ),
         # Convert LAR data to combined modified LAR data
@@ -70,7 +70,7 @@ for year in (2019, 2020, 2021, 2022, 2023, 2024):
                 "params:combined_mlar_legacy_column_names_map_list",
             ],
             outputs=f"combined_modified_lar_raw_parquets_{year}",
-            tags=f"{year}_Filing_Season",
+            tags=[f"{year}_Filing_Season", f"{year}_Annual_Filing_Season"],
             name=f"generate_combined_modified_lar_for_{year}",
         ),
         # Create public modified LAR flat file
@@ -82,7 +82,7 @@ for year in (2019, 2020, 2021, 2022, 2023, 2024):
                 f"archive_public_modified_lar_flat_file_{year}",
                 f"public_mlar_row_count_{year}",
             ],
-            tags=f"{year}_Filing_Season",
+            tags=[f"{year}_Filing_Season", f"{year}_Annual_Filing_Season"],
             name=f"generate_public_modified_lar_flat_file_for_{year}",
         ),
         # Create combined modified LAR flat file and header file
@@ -94,7 +94,7 @@ for year in (2019, 2020, 2021, 2022, 2023, 2024):
                 f"combined_modified_lar_header_flat_file_{year}",
                 f"combined_mlar_row_count_{year}",
             ],
-            tags=f"{year}_Filing_Season",
+            tags=[f"{year}_Filing_Season", f"{year}_Annual_Filing_Season"],
             name=f"generate_combined_modified_lar_flat_file_for_{year}",
         ),
         # Analyze modified LAR flat file
@@ -102,7 +102,7 @@ for year in (2019, 2020, 2021, 2022, 2023, 2024):
             withkwargs(analyze_mlar_flat_file, year=year),
             inputs=[f"public_modified_lar_flat_file_{year}", "parameters"],
             outputs=f"analyzed_mlar_flat_file_{year}",
-            tags=f"{year}_Filing_Season",
+            tags=[f"{year}_Filing_Season", f"{year}_Annual_Filing_Season"],
             name=f"generate_analyzed_mlar_flat_file_for_{year}",
         ),
         # Create panel flat file
@@ -115,7 +115,7 @@ for year in (2019, 2020, 2021, 2022, 2023, 2024):
                 "params:institutions_columns",
             ],
             outputs=f"institutions_flat_file_{year}",
-            tags=f"{year}_Filing_Season",
+            tags=[f"{year}_Filing_Season", f"{year}_Annual_Filing_Season"],
             name=f"generate_institutions_flat_file_for_{year}",
         ),
         # Create reduced LAR flat file used for aggregate and disclosure reports
@@ -129,7 +129,7 @@ for year in (2019, 2020, 2021, 2022, 2023, 2024):
                 f"reduced_lar_reports_parquet_{year}",
                 f"reduced_lar_reports_row_count_{year}",
             ],
-            tags=f"{year}_Filing_Season",
+            tags=[f"{year}_Filing_Season", f"{year}_Annual_Filing_Season"],
             name=f"generate_reduced_lar_reports_for_{year}",
         ),
         # Create regulator transmittal sheet flat file
@@ -137,7 +137,7 @@ for year in (2019, 2020, 2021, 2022, 2023, 2024):
             create_regulator_ts_flat_file,
             inputs=[f"ts_raw_parquet_{year}", "params:regulator_ts_columns"],
             outputs=f"regulator_ts_flat_file_{year}",
-            tags=f"{year}_Filing_Season",
+            tags=[f"{year}_Filing_Season", f"{year}_Annual_Filing_Season"],
             name=f"generate_regulator_ts_flat_file_for_{year}",
         ),
         # Create public transmittal sheet flat file
@@ -151,7 +151,7 @@ for year in (2019, 2020, 2021, 2022, 2023, 2024):
                 f"public_ts_flat_file_{year}",
                 f"archive_public_ts_flat_file_{year}",
             ],
-            tags=f"{year}_Filing_Season",
+            tags=[f"{year}_Filing_Season", f"{year}_Annual_Filing_Season"],
             name=f"generate_public_ts_flat_file_for_{year}",
         ),
     ]

--- a/hmda-etl-pipeline/src/hmda_etl_pipeline/pipelines/data_publisher/pipeline.py
+++ b/hmda-etl-pipeline/src/hmda_etl_pipeline/pipelines/data_publisher/pipeline.py
@@ -15,7 +15,6 @@ from .nodes import (
     create_mlar_flat_file,
     create_lar_flat_file,
     analyze_mlar_flat_file,
-    validate_lar_and_mlar_row_counts,
     create_institutions_flat_file,
     create_regulator_ts_flat_file,
     create_public_ts_flat_file,
@@ -105,22 +104,6 @@ for year in (2019, 2020, 2021, 2022, 2023, 2024):
             outputs=f"analyzed_mlar_flat_file_{year}",
             tags=f"{year}_Filing_Season",
             name=f"generate_analyzed_mlar_flat_file_for_{year}",
-        ),
-        # Validate the row counts for the LAR and public modified LAR flat files
-        node(
-            validate_lar_and_mlar_row_counts,
-            inputs=[f"reg_lar_row_count_{year}", f"public_mlar_row_count_{year}"],
-            outputs=None,
-            tags=f"{year}_Filing_Season",
-            name=f"validate_lar_and_public_mlar_row_counts_for_{year}",
-        ),
-        # Validate the row counts for the LAR and combined modified LAR flat files
-        node(
-            validate_lar_and_mlar_row_counts,
-            inputs=[f"reg_lar_row_count_{year}", f"combined_mlar_row_count_{year}"],
-            outputs=None,
-            tags=f"{year}_Filing_Season",
-            name=f"validate_lar_and_combined_mlar_row_counts_for_{year}",
         ),
         # Create panel flat file
         node(


### PR DESCRIPTION
removing mlar validations.  current mlar validations are comparing the length/count of mlar with lar table.  this is redundant as mlar table is generated from lar table therefore the size should be always equal.  In addition, the validation functions are executed after mlar functions so the validations are not effective as intended.

Beside the validation removal, I also added annual tag for yearly nodes in data_publisher pipeline to match our ingest pipeline's new annual tag.

Test:
- Generate data locally using  ingest pipeline on '2023_Annual_Filing_Season' tag
- run `kedro run --tags="2023_Annual_Filing_Season" --env=local --params=post_to_mm=False --pipeline=data_publisher`
- verified that data_publisher pipeline nodes are executed without needing these validations

closes #4 
