### PR TITLE
Handle keyword values in data_publisher high/low checks

### DIFF
--- a/hmda-etl-pipeline/src/hmda_etl_pipeline/pipelines/data_publisher/checks.py
+++ b/hmda-etl-pipeline/src/hmda_etl_pipeline/pipelines/data_publisher/checks.py
@@ -24,13 +24,15 @@ def check_invalidity(mlar_df: pd.DataFrame, params: Dict, year: int, col: str) -
 
 def check_high_values(mlar_df: pd.DataFrame, params: Dict, year: int, col: str) -> None:
     def high_value(row: pd.Series, col: str) -> bool:
-        return row[col] >= get_var(params, col, "high_value")
+        val = pd.to_numeric(row[col], errors="coerce")
+        return pd.notna(val) and val >= get_var(params, col, "high_value")
     add_markers(mlar_df, col, high_value, "H")
 
 
 def check_low_values(mlar_df: pd.DataFrame, params: Dict, year: int, col: str) -> None:
     def low_value(row: pd.Series, col: str) -> bool:
-        return row[col] <= get_var(params, col, "low_value")
+        val = pd.to_numeric(row[col], errors="coerce")
+        return pd.notna(val) and val <= get_var(params, col, "low_value")
     add_markers(mlar_df, col, low_value, "L")
 
 

--- a/hmda-etl-pipeline/src/tests/pipelines/data_publisher/test_checks.py
+++ b/hmda-etl-pipeline/src/tests/pipelines/data_publisher/test_checks.py
@@ -1,0 +1,42 @@
+"""
+Verify the high/low value checks handle non-numeric keyword cells
+(for example "Exempt") without raising a TypeError.
+"""
+
+import pandas as pd
+
+from hmda_etl_pipeline.pipelines.data_publisher.checks import (
+    check_high_values,
+    check_low_values,
+)
+
+
+def make_mlar_df():
+    """A small MLAR frame whose origination_charges column mixes numeric
+    strings with the "Exempt" keyword, as happens on real HMDA data.
+    """
+    df = pd.DataFrame(
+        {
+            "lei": ["a", "b", "c"],
+            "origination_charges": ["100", "Exempt", "9999"],
+        }
+    )
+    df["Analysis"] = ""
+    return df
+
+
+PARAMS = {"check_vars": {"default": {"high_value": 9000, "low_value": 10}}}
+
+
+def test_check_high_values_skips_keyword_cells():
+    df = make_mlar_df()
+    check_high_values(df, PARAMS, 2023, "origination_charges")
+    # Only the 9999 row is a high outlier; "Exempt" and "100" stay untouched.
+    assert list(df["Analysis"]) == ["", "", "002H"]
+
+
+def test_check_low_values_skips_keyword_cells():
+    df = make_mlar_df()
+    check_low_values(df, PARAMS, 2023, "origination_charges")
+    # Nothing is below the low threshold of 10, and "Exempt" is ignored.
+    assert list(df["Analysis"]) == ["", "", ""]


### PR DESCRIPTION
This fixes the TypeError from issue #14. The high and low value checks in the data_publisher pipeline compare each cell straight against the threshold, but some MLAR columns (like origination_charges) can hold keyword strings such as "Exempt", and that comparison blows up with ">=" not supported between instances of "str" and "int". I coerce the cell to numeric first and treat anything non-numeric as not an outlier, so the keyword and NA rows are just skipped while the real high/low flagging still works. I also added a small unit test with a mixed ["100", "Exempt", "9999"] column that fails on main and passes with the change. Thanks for taking a look.